### PR TITLE
Allow extra flags in CPPFLAGS, CXXFLAGS and LDFLAGS.

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,19 +1,19 @@
-CPP = g++
-CPPFLAGS = -I . -O3
+CXX = g++
+BAIT_CXXFLAGS = -I . -O3
 
 OBJECTS1 = bait-fisher-helper.o bait-fisher.o Csequence_cluster_and_center_sequence.o mydir-unix.o
 OBJECTS2 = bait-filter.o global-types-and-parameters.o
 
 %.o: %.cpp
-	$(CPP) $(CPPFLAGS) -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(BAIT_CXXFLAGS) $(CXXFLAGS) -c $< -o $@
 
 default: BaitFisher-v1.2.7 BaitFilter-v1.0.5
 
 BaitFisher-v1.2.7: $(OBJECTS1)
-	$(CPP) $(CPPFLAGS) -lstdc++ $(OBJECTS1) -o $@
+	$(CXX) $(BAIT_CXXFLAGS) $(CXXFLAGS) $(LDFLAGS) -lstdc++ $(OBJECTS1) -o $@
 
 BaitFilter-v1.0.5: $(OBJECTS2)
-	$(CPP) $(CPPFLAGS) -lstdc++ $(OBJECTS2) -o $@
+	$(CXX) $(BAIT_CXXFLAGS) $(CXXFLAGS) $(LDFLAGS) -lstdc++ $(OBJECTS2) -o $@
 
 clean:
 	rm -f *.o

--- a/makefile_win
+++ b/makefile_win
@@ -1,21 +1,21 @@
 ## Requires mingw to be installed".
 
-CPP = g++
-CPPFLAGS = -I . -O3
+CXX = g++
+BAIT_CXXFLAGS = -I . -O3
 
 OBJECTS1 = bait-fisher-helper.o bait-fisher.o Csequence_cluster_and_center_sequence.o mydir-unix.o
 OBJECTS2 = bait-filter.o global-types-and-parameters.o
 
 %.o: %.cpp
-	$(CPP) $(CPPFLAGS) -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(BAIT_CXXFLAGS) $(CXXFLAGS) -c $< -o $@
 
 default: BaitFisher-v1.2.7 BaitFilter-v1.0.5
 
 BaitFisher-v1.2.7: $(OBJECTS1)
-	$(CPP) $(CPPFLAGS) -lstdc++ $(OBJECTS1) -o $@
+	$(CXX) $(BAIT_CXXFLAGS) $(CXXFLAGS) $(LDFLAGS) -lstdc++ $(OBJECTS1) -o $@
 
 BaitFilter-v1.0.5: $(OBJECTS2)
-	$(CPP) $(CPPFLAGS) -lstdc++ $(OBJECTS2) -o $@
+	$(CXX) $(BAIT_CXXFLAGS) $(CXXFLAGS) $(LDFLAGS) -lstdc++ $(OBJECTS2) -o $@
 
 clean:
 	rm -f *.o


### PR DESCRIPTION
Use the standard meaning of the variables CXX, CPPFLAGS, CXXFLAGS and
LDFLAGS and does not overwrite them, so that makefile users (eg. Debian
packagers) can pass extra build flags in environment variables.

Reference:
https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html
https://www.gnu.org/software/make/manual/html_node/Catalogue-of-Rules.html
https://www.gnu.org/prep/standards/standards.html#Command-Variables
https://wiki.debian.org/UpstreamGuide#Make